### PR TITLE
feat: update to match the new 0.15.X schema changes

### DIFF
--- a/models/_models.yml
+++ b/models/_models.yml
@@ -46,13 +46,20 @@ models:
             - data_source
 
 # Clinical input
+  - name: appointment
+    columns:
+      - name: appointment_id
+        tests:
+          - unique
+          - not_null
+
   - name: condition
     columns:
       - name: condition_id
         tests:
           - unique
           - not_null
-
+  
   - name: encounter
     columns:
       - name: encounter_id
@@ -60,6 +67,13 @@ models:
           - unique
           - not_null
 
+  - name: immunization
+    columns:
+      - name: immunization_id
+        tests:
+          - unique
+          - not_null
+ 
   - name: lab_result
     columns:
       - name: lab_result_id

--- a/models/final/appointment.sql
+++ b/models/final/appointment.sql
@@ -1,0 +1,35 @@
+select {% if target.type == 'fabric' %} top 0 {% else %}{% endif %}
+      cast(null as {{ dbt.type_string() }}) as appointment_id
+    , cast(null as {{ dbt.type_string() }}) as person_id
+    , cast(null as {{ dbt.type_string() }}) as patient_id
+    , cast(null as {{ dbt.type_string() }}) as encounter_id
+    , cast(null as {{ dbt.type_string() }}) as source_appointment_type_code
+    , cast(null as {{ dbt.type_string() }}) as source_appointment_type_description
+    , cast(null as {{ dbt.type_string() }}) as normalized_appointment_type_code
+    , cast(null as {{ dbt.type_string() }}) as normalized_appointment_type_description
+    , cast(null as {{ dbt.type_timestamp() }}) as start_datetime
+    , cast(null as {{ dbt.type_timestamp() }}) as end_datetime
+    , cast(null as {{ dbt.type_string() }}) as duration
+    , cast(null as {{ dbt.type_string() }}) as location_id
+    , cast(null as {{ dbt.type_string() }}) as practitioner_id
+    , cast(null as {{ dbt.type_string() }}) as source_status
+    , cast(null as {{ dbt.type_string() }}) as normalized_status
+    , cast(null as {{ dbt.type_string() }}) as appointment_specialty
+    , cast(null as {{ dbt.type_string() }}) as reason
+    , cast(null as {{ dbt.type_string() }}) as source_reason_code_type
+    , cast(null as {{ dbt.type_string() }}) as source_reason_code
+    , cast(null as {{ dbt.type_string() }}) as source_reason_description
+    , cast(null as {{ dbt.type_string() }}) as normalized_reason_code_type
+    , cast(null as {{ dbt.type_string() }}) as normalized_reason_code
+    , cast(null as {{ dbt.type_string() }}) as normalized_reason_description
+    , cast(null as {{ dbt.type_string() }}) as cancellation_reason
+    , cast(null as {{ dbt.type_string() }}) as source_cancellation_reason_code_type
+    , cast(null as {{ dbt.type_string() }}) as source_cancellation_reason_code
+    , cast(null as {{ dbt.type_string() }}) as source_cancellation_reason_description
+    , cast(null as {{ dbt.type_string() }}) as normalized_cancellation_reason_code_type
+    , cast(null as {{ dbt.type_string() }}) as normalized_cancellation_reason_code
+    , cast(null as {{ dbt.type_string() }}) as normalized_cancellation_reason_description
+    , cast(null as {{ dbt.type_string() }}) as data_source
+    , cast(null as {{ dbt.type_string() }}) as file_name
+    , cast(null as {{ dbt.type_timestamp() }}) as ingest_datetime
+{% if target.type == 'fabric' %} {% else %} limit 0 {% endif %}

--- a/models/final/eligibility.sql
+++ b/models/final/eligibility.sql
@@ -17,8 +17,12 @@ select {% if target.type == 'fabric' %} top 0 {% else %}{% endif %}
     , cast(null as {{ dbt.type_string() }}) as medicare_status_code
     , cast(null as {{ dbt.type_string() }}) as group_id
     , cast(null as {{ dbt.type_string() }}) as group_name
+    , cast(null as {{ dbt.type_string() }}) as name_suffix
     , cast(null as {{ dbt.type_string() }}) as first_name
+    , cast(null as {{ dbt.type_string() }}) as middle_name
     , cast(null as {{ dbt.type_string() }}) as last_name
+    , cast(null as {{ dbt.type_string() }}) as email
+    , cast(null as {{ dbt.type_string() }}) as ethnicity
     , cast(null as {{ dbt.type_string() }}) as social_security_number
     , cast(null as {{ dbt.type_string() }}) as subscriber_relation
     , cast(null as {{ dbt.type_string() }}) as address

--- a/models/final/immunization.sql
+++ b/models/final/immunization.sql
@@ -1,0 +1,25 @@
+select {% if target.type == 'fabric' %} top 0 {% else %}{% endif %}
+      cast(null as {{ dbt.type_string() }}) as immunization_id
+    , cast(null as {{ dbt.type_string() }}) as person_id
+    , cast(null as {{ dbt.type_string() }}) as patient_id
+    , cast(null as {{ dbt.type_string() }}) as encounter_id
+    , cast(null as {{ dbt.type_string() }}) as source_code_type
+    , cast(null as {{ dbt.type_string() }}) as source_code
+    , cast(null as {{ dbt.type_string() }}) as source_description
+    , cast(null as {{ dbt.type_string() }}) as normalized_code_type
+    , cast(null as {{ dbt.type_string() }}) as normalized_code
+    , cast(null as {{ dbt.type_string() }}) as normalized_description
+    , cast(null as {{ dbt.type_string() }}) as status
+    , cast(null as {{ dbt.type_string() }}) as status_reason
+    , cast(null as date) as occurrence_date
+    , cast(null as {{ dbt.type_string() }}) as source_dose
+    , cast(null as {{ dbt.type_string() }}) as normalized_dose
+    , cast(null as {{ dbt.type_string() }}) as lot_number
+    , cast(null as {{ dbt.type_string() }}) as body_site
+    , cast(null as {{ dbt.type_string() }}) as route
+    , cast(null as {{ dbt.type_string() }}) as location_id
+    , cast(null as {{ dbt.type_string() }}) as practitioner_id
+    , cast(null as {{ dbt.type_string() }}) as data_source
+    , cast(null as {{ dbt.type_string() }}) as file_name
+    , cast(null as {{ dbt.type_timestamp() }}) as ingest_datetime
+{% if target.type == 'fabric' %} {% else %} limit 0 {% endif %}

--- a/models/final/lab_result.sql
+++ b/models/final/lab_result.sql
@@ -4,18 +4,22 @@ select {% if target.type == 'fabric' %} top 0 {% else %}{% endif %}
     , cast(null as {{ dbt.type_string() }}) as patient_id
     , cast(null as {{ dbt.type_string() }}) as encounter_id
     , cast(null as {{ dbt.type_string() }}) as accession_number
-    , cast(null as {{ dbt.type_string() }}) as source_code_type
-    , cast(null as {{ dbt.type_string() }}) as source_code
-    , cast(null as {{ dbt.type_string() }}) as source_description
-    , cast(null as {{ dbt.type_string() }}) as source_component
-    , cast(null as {{ dbt.type_string() }}) as normalized_code_type
-    , cast(null as {{ dbt.type_string() }}) as normalized_code
-    , cast(null as {{ dbt.type_string() }}) as normalized_description
-    , cast(null as {{ dbt.type_string() }}) as normalized_component
+    , cast(null as {{ dbt.type_string() }}) as source_order_type
+    , cast(null as {{ dbt.type_string() }}) as source_order_code
+    , cast(null as {{ dbt.type_string() }}) as source_order_description
+    , cast(null as {{ dbt.type_string() }}) as source_component_code
+    , cast(null as {{ dbt.type_string() }}) as source_component_type
+    , cast(null as {{ dbt.type_string() }}) as source_component_description
+    , cast(null as {{ dbt.type_string() }}) as normalized_order_type
+    , cast(null as {{ dbt.type_string() }}) as normalized_order_code
+    , cast(null as {{ dbt.type_string() }}) as normalized_order_description
+    , cast(null as {{ dbt.type_string() }}) as normalized_component_code
+    , cast(null as {{ dbt.type_string() }}) as normalized_component_type
+    , cast(null as {{ dbt.type_string() }}) as normalized_component_description
     , cast(null as {{ dbt.type_string() }}) as status
     , cast(null as {{ dbt.type_string() }}) as result
-    , cast(null as date) as result_date
-    , cast(null as date) as collection_date
+    , cast(null as {{ dbt.type_timestamp() }}) as result_datetime
+    , cast(null as {{ dbt.type_timestamp() }}) as collection_datetime
     , cast(null as {{ dbt.type_string() }}) as source_units
     , cast(null as {{ dbt.type_string() }}) as normalized_units
     , cast(null as {{ dbt.type_string() }}) as source_reference_range_low

--- a/models/final/patient.sql
+++ b/models/final/patient.sql
@@ -1,10 +1,14 @@
 select
       cast(null as {{ dbt.type_string() }}) as person_id
     , cast(null as {{ dbt.type_string() }}) as patient_id
+    , cast(null as {{ dbt.type_string() }}) as name_suffix
     , cast(null as {{ dbt.type_string() }}) as first_name
+    , cast(null as {{ dbt.type_string() }}) as middle_name
     , cast(null as {{ dbt.type_string() }}) as last_name
+    , cast(null as {{ dbt.type_string() }}) as email
     , cast(null as {{ dbt.type_string() }}) as sex
     , cast(null as {{ dbt.type_string() }}) as race
+    , cast(null as {{ dbt.type_string() }}) as ethnicity
     , cast(null as date) as birth_date
     , cast(null as date) as death_date
     , cast(null as {{ dbt.type_int() }}) as death_flag

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: tuva-health/the_tuva_project
-    version: [">=0.14.0","<0.15.0"]
+    version: [">=0.15.0","<0.16.0"]


### PR DESCRIPTION
## Describe your changes

- Upgraded the TUVA version to v0.15 in `packages.yml`.
- Added two new models: `appointment.sql` and `immunization.sql`.
- Adjusted the following models to align with the v0.15 schema:
    - `eligibility.sql`
    - `patient.sql`
    - `lab_result.sql`

## How has this been tested?

Ran `dbt build -s modified models --full-refresh`

## Reviewer focus

- Please focus on `packages.yml` for the version upgrade.
- Please review the addition of `appointment.sql` and `immunization.sql`.
- Please focus on changes in `eligibility.sql`, `patient.sql`, and `lab_result.sql` for alignment with the v0.15 schema.