### PR TITLE
Update eligibility.sql

### DIFF
--- a/models/final/eligibility.sql
+++ b/models/final/eligibility.sql
@@ -17,7 +17,9 @@ select {% if target.type == 'fabric' %} top 0 {% else %}{% endif %}
     , cast(null as {{ dbt.type_string() }}) as medicare_status_code
     , cast(null as {{ dbt.type_string() }}) as group_id
     , cast(null as {{ dbt.type_string() }}) as group_name
+    , cast(null as {{ dbt.type_string() }}) as name_suffix,  
     , cast(null as {{ dbt.type_string() }}) as first_name
+    , cast(null as {{ dbt.type_string() }}) as middle_name
     , cast(null as {{ dbt.type_string() }}) as last_name
     , cast(null as {{ dbt.type_string() }}) as social_security_number
     , cast(null as {{ dbt.type_string() }}) as subscriber_relation
@@ -26,6 +28,8 @@ select {% if target.type == 'fabric' %} top 0 {% else %}{% endif %}
     , cast(null as {{ dbt.type_string() }}) as state
     , cast(null as {{ dbt.type_string() }}) as zip_code
     , cast(null as {{ dbt.type_string() }}) as phone
+    , cast(null as {{ dbt.type_string() }}) as email
+    , cast(null as {{ dbt.type_string() }}) as ethnicity
     , cast(null as {{ dbt.type_string() }}) as data_source
     , cast(null as {{ dbt.type_string() }}) as file_name
     , cast(null as date) as file_date


### PR DESCRIPTION
Added new fields needed to allow data_quality models to run.

The information for what needs to be in the input eligibility model in [Claims Mapping Guide](https://thetuvaproject.com/connectors/claims-mapping-guide) and the [eligibility connector template](https://github.com/tuva-health/connector_template/blob/main/models/final/eligibility.sql) doesn't match what's listed in [Input Layer](https://thetuvaproject.com/connectors/input-layer). The following five checks failed for me, so it looks like [Input Layer](https://thetuvaproject.com/connectors/input-layer) is the most up to date:
- https://github.com/tuva-health/tuva/blob/main/models/data_quality/dqi/intermediate/atomic_checks/claims/eligibility/data_quality__eligibility_email.sql
- https://github.com/tuva-health/tuva/blob/main/models/data_quality/dqi/intermediate/atomic_checks/claims/eligibility/data_quality__eligibility_ethnicity.sql
- https://github.com/tuva-health/tuva/blob/main/models/data_quality/dqi/intermediate/atomic_checks/claims/eligibility/data_quality__eligibility_middle_name.sql
- https://github.com/tuva-health/tuva/blob/main/models/data_quality/dqi/intermediate/atomic_checks/claims/eligibility/data_quality__eligibility_name_suffix.sql
- https://github.com/tuva-health/tuva/blob/main/models/claims_preprocessing/normalized_input/intermediate/normalized_input__int_eligibility_dates_normalize.sql
